### PR TITLE
more fields for missionSlotGroups and missionSlots

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "vision": "^4.1.1"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.8",
+    "@types/bluebird": "3.5.21",
     "@types/bluebird-global": "^3.5.3",
     "@types/boom": "^4.3.7",
     "@types/bunyan": "^1.8.2",

--- a/src/api/routes/v1/mission.ts
+++ b/src/api/routes/v1/mission.ts
@@ -10,7 +10,7 @@ import { missionSlotSchema } from '../../../shared/schemas/missionSlot';
 import { missionSlotGroupSchema } from '../../../shared/schemas/missionSlotGroup';
 import { missionSlotRegistrationSchema } from '../../../shared/schemas/missionSlotRegistration';
 import { permissionSchema } from '../../../shared/schemas/permission';
-import {TacticalSymbol, tacticalSymbols} from '../../../shared/types/tacticalSymbol';
+import {TACTICAL_SYMBOL, tacticalSymbols} from '../../../shared/types/tacticalSymbol';
 import * as controller from '../../controllers/v1/mission';
 
 /**
@@ -1149,7 +1149,7 @@ export const mission = [
                     description: Joi.string().allow(null).min(1).default(null).required().description('Optional description of the mission slot group, explaining ' +
                         'the slot group\'s role or callsign').example('Leads the mission, callsign "Luchs"'),
                     radioFrequency: Joi.string().optional().max(255).default(null).description('Radio frequency or channel the group uses').example('52.3 MHz'),
-                    tacticalSymbol: Joi.string().allow(tacticalSymbols).optional().default(null).description('tactical symbol').example(TacticalSymbol.mech_inf),
+                    tacticalSymbol: Joi.string().allow(tacticalSymbols).optional().default(null).description('tactical symbol').example(TACTICAL_SYMBOL.mech_inf),
                     vehicle: Joi.string().max(64).optional().default(null).description('Vehicle the group uses').example('BTR-70'),
                     minSlottedPlayerCount: Joi.number()
                         .positive().allow(0).integer().optional().default(0)

--- a/src/api/routes/v1/mission.ts
+++ b/src/api/routes/v1/mission.ts
@@ -10,6 +10,7 @@ import { missionSlotSchema } from '../../../shared/schemas/missionSlot';
 import { missionSlotGroupSchema } from '../../../shared/schemas/missionSlotGroup';
 import { missionSlotRegistrationSchema } from '../../../shared/schemas/missionSlotRegistration';
 import { permissionSchema } from '../../../shared/schemas/permission';
+import {TacticalSymbol, tacticalSymbols} from '../../../shared/types/tacticalSymbol';
 import * as controller from '../../controllers/v1/mission';
 
 /**
@@ -1147,6 +1148,12 @@ export const mission = [
                     title: Joi.string().min(1).max(255).required().description('Title of the slot group').example('Platoon Luchs'),
                     description: Joi.string().allow(null).min(1).default(null).required().description('Optional description of the mission slot group, explaining ' +
                         'the slot group\'s role or callsign').example('Leads the mission, callsign "Luchs"'),
+                    radioFrequency: Joi.string().optional().max(255).default(null).description('Radio frequency or channel the group uses').example('52.3 MHz'),
+                    tacticalSymbol: Joi.string().allow(tacticalSymbols).optional().default(null).description('tactical symbol').example(TacticalSymbol.mech_inf),
+                    vehicle: Joi.string().max(64).optional().default(null).description('Vehicle the group uses').example('BTR-70'),
+                    minSlottedPlayerCount: Joi.number()
+                        .positive().allow(0).integer().optional().default(0)
+                        .description('Lock slots of this group until at least N players have slotted into the mission').example(12),
                     insertAfter: Joi.number().integer().positive().allow(0).default(0).required().description('Order number of slot group the new group should be inserted ' +
                         'after. The order number created will be incremented by one and all higher order numbers adapted accordingly').example(9)
                 }).required()
@@ -1466,6 +1473,9 @@ export const mission = [
                 }),
                 payload: Joi.object().required().keys({
                     title: Joi.string().min(1).max(255).optional().description('New title of the slot').example('Platoon Lead'),
+                    minSlottedPlayerCount: Joi.number()
+                        .positive().allow(0).integer().optional().default(0)
+                        .description('Lock slot until at least N players have slotted into the mission').example(12),
                     difficulty: Joi.number().integer().positive().allow(0).min(0).max(4).optional().description('New difficulity of the slot, ranging from 0 (easiest) ' +
                         'to 4 (hardest)').example(4),
                     description: Joi.string().allow(null).min(1).optional().description('New optional short description of the slot')

--- a/src/shared/migrations/040-add-slot-groups-parent-group.ts
+++ b/src/shared/migrations/040-add-slot-groups-parent-group.ts
@@ -1,16 +1,23 @@
 import { DataTypes } from 'sequelize';
 
 /**
- * Adds the requiredDLCs column to the MissionSlots table
+ * Enables hierarchy to MissionSlotGroups
  */
 module.exports = {
     up: async (queryInterface: any): Promise<void> => {
-        await queryInterface.addColumn('missionSlotGroups', 'parentGroup', {
+        await queryInterface.addColumn('missionSlotGroups', 'parentGroupUid', {
             type: DataTypes.UUID,
-            allowNull: true
+            allowNull: true,
+            defaultValue: null,
+            references: {
+                model: 'missionSlotGroups',
+                key: 'uid'
+            },
+            onDelete: 'CASCADE',
+            onUpdate: 'CASCADE'
         });
     },
     down: async (queryInterface: any): Promise<void> => {
-        await queryInterface.removeColumn('missionSlotGroups', 'parentGroup');
+        await queryInterface.removeColumn('missionSlotGroups', 'parentGroupUid');
     }
 };

--- a/src/shared/migrations/040-add-slot-groups-parent-group.ts
+++ b/src/shared/migrations/040-add-slot-groups-parent-group.ts
@@ -1,0 +1,16 @@
+import { DataTypes } from 'sequelize';
+
+/**
+ * Adds the requiredDLCs column to the MissionSlots table
+ */
+module.exports = {
+    up: async (queryInterface: any): Promise<void> => {
+        await queryInterface.addColumn('missionSlotGroups', 'parentGroup', {
+            type: DataTypes.UUID,
+            allowNull: true
+        });
+    },
+    down: async (queryInterface: any): Promise<void> => {
+        await queryInterface.removeColumn('missionSlotGroups', 'parentGroup');
+    }
+};

--- a/src/shared/migrations/041-add-more-slot-groups-attributes.ts
+++ b/src/shared/migrations/041-add-more-slot-groups-attributes.ts
@@ -1,0 +1,33 @@
+import { DataTypes } from 'sequelize';
+
+/**
+ * Adds the requiredDLCs column to the MissionSlots table
+ */
+module.exports = {
+    up: async (queryInterface: any): Promise<void> => {
+        await queryInterface.addColumn('missionSlotGroups', 'radioFrequency', {
+            type: DataTypes.DOUBLE,
+            allowNull: true
+        });
+        await queryInterface.addColumn('missionSlotGroups', 'tacticalSymbol', {
+            type: DataTypes.ENUM,
+            values: ['inf'],
+            allowNull: true
+        });
+        await queryInterface.addColumn('missionSlotGroups', 'vehicle', {
+            type: DataTypes.STRING,
+            allowNull: true
+        });
+        await queryInterface.addColumn('missionSlotGroups', 'minSlottedPlayerCount', {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0
+        });
+    },
+    down: async (queryInterface: any): Promise<void> => {
+        await queryInterface.removeColumn('missionSlotGroups', 'minSlottedPlayerCount');
+        await queryInterface.removeColumn('missionSlotGroups', 'vehicle');
+        await queryInterface.removeColumn('missionSlotGroups', 'tacticalSymbol');
+        await queryInterface.removeColumn('missionSlotGroups', 'radioFrequency');
+    }
+};

--- a/src/shared/migrations/041-add-more-slot-groups-attributes.ts
+++ b/src/shared/migrations/041-add-more-slot-groups-attributes.ts
@@ -1,22 +1,26 @@
 import { DataTypes } from 'sequelize';
+import {tacticalSymbols} from '../types/tacticalSymbol';
 
 /**
- * Adds the requiredDLCs column to the MissionSlots table
+ * Adds optional radioFrequency, tacticalSymbol, vehicle, minSlottedPlayerCount attributes to MissionSlotGroup
  */
 module.exports = {
     up: async (queryInterface: any): Promise<void> => {
         await queryInterface.addColumn('missionSlotGroups', 'radioFrequency', {
-            type: DataTypes.DOUBLE,
-            allowNull: true
+            type: DataTypes.STRING,
+            allowNull: true,
+            defaultValue: null
         });
         await queryInterface.addColumn('missionSlotGroups', 'tacticalSymbol', {
             type: DataTypes.ENUM,
-            values: ['inf'],
-            allowNull: true
+            values: tacticalSymbols,
+            allowNull: true,
+            defaultValue: null
         });
         await queryInterface.addColumn('missionSlotGroups', 'vehicle', {
             type: DataTypes.STRING,
-            allowNull: true
+            allowNull: true,
+            defaultValue: null
         });
         await queryInterface.addColumn('missionSlotGroups', 'minSlottedPlayerCount', {
             type: DataTypes.INTEGER,

--- a/src/shared/migrations/042-add-more-slot-attributes.ts
+++ b/src/shared/migrations/042-add-more-slot-attributes.ts
@@ -1,0 +1,17 @@
+import { DataTypes } from 'sequelize';
+
+/**
+ * Adds the requiredDLCs column to the MissionSlots table
+ */
+module.exports = {
+    up: async (queryInterface: any): Promise<void> => {
+        await queryInterface.addColumn('missionSlots', 'minSlottedPlayerCount', {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0
+        });
+    },
+    down: async (queryInterface: any): Promise<void> => {
+        await queryInterface.removeColumn('missionSlots', 'minSlottedPlayerCount');
+    }
+};

--- a/src/shared/migrations/042-add-more-slot-attributes.ts
+++ b/src/shared/migrations/042-add-more-slot-attributes.ts
@@ -1,7 +1,7 @@
 import { DataTypes } from 'sequelize';
 
 /**
- * Adds the requiredDLCs column to the MissionSlots table
+ * Adds optional minSlottedPlayerCount to slots
  */
 module.exports = {
     up: async (queryInterface: any): Promise<void> => {

--- a/src/shared/models/MissionSlot.ts
+++ b/src/shared/models/MissionSlot.ts
@@ -95,6 +95,18 @@ export class MissionSlot extends Model {
     public title: string;
 
     /**
+     * Minimum number of assigned slots for this slot to be open for slotting.
+     * @type {number}
+     * @memberOf MissionSlot
+     */
+    @Attribute({
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 0
+    })
+    public minSlottedPlayerCount: number;
+
+    /**
      * Order number for sorting slots within a slot group
      *
      * @type {number}
@@ -505,6 +517,7 @@ export class MissionSlot extends Model {
             uid: this.uid,
             slotGroupUid: this.slotGroupUid,
             title: this.title,
+            minSlottedPlayerCount: this.minSlottedPlayerCount,
             orderNumber: this.orderNumber,
             difficulty: this.difficulty,
             description: _.isNil(this.description) ? null : this.description,
@@ -535,6 +548,7 @@ export interface IPublicMissionSlot {
     uid: string;
     slotGroupUid: string;
     title: string;
+    minSlottedPlayerCount: number;
     orderNumber: number;
     difficulty: number;
     detailedDescription: string | null;
@@ -559,6 +573,7 @@ export interface IPublicMissionSlot {
 export interface IMissionSlotCreatePayload {
     slotGroupUid: string;
     title: string;
+    minSlottedPlayerCount?: number;
     orderNumber: number;
     difficulty: number;
     detailedDescription: string | null;

--- a/src/shared/models/MissionSlot.ts
+++ b/src/shared/models/MissionSlot.ts
@@ -573,7 +573,7 @@ export interface IPublicMissionSlot {
 export interface IMissionSlotCreatePayload {
     slotGroupUid: string;
     title: string;
-    minSlottedPlayerCount?: number;
+    minSlottedPlayerCount: number;
     orderNumber: number;
     difficulty: number;
     detailedDescription: string | null;

--- a/src/shared/models/MissionSlotGroup.ts
+++ b/src/shared/models/MissionSlotGroup.ts
@@ -13,6 +13,7 @@ import { Attribute, Options } from 'sequelize-decorators';
 
 import sequelize from '../util/sequelize';
 
+import {tacticalSymbols} from '../types/tacticalSymbol';
 import { Mission } from './Mission';
 import { IPublicMissionSlot, MissionSlot } from './MissionSlot';
 
@@ -36,7 +37,8 @@ export class MissionSlotGroup extends Model {
      * @static
      * @type {{
      *         mission: BelongsTo,
-     *         slots: HasMany
+     *         slots: HasMany,
+     *         parentGroup: HasOne
      *     }}
      * @memberof MissionSlotGroup
      */
@@ -82,6 +84,7 @@ export class MissionSlotGroup extends Model {
     @Attribute({
         type: DataTypes.UUID,
         allowNull: true,
+        defaultValue: null,
         references: {
             model: MissionSlotGroup,
             key: 'uid'
@@ -107,18 +110,16 @@ export class MissionSlotGroup extends Model {
     public title: string;
 
     /**
-     * Radio frequency this unit uses for comms (in MHz)
-     * @type {number}
+     * Radio frequency this unit uses for comms
+     * @type {string}
      * @memberOf MissionSlotGroup
      */
     @Attribute({
-        type: DataTypes.DOUBLE,
+        type: DataTypes.STRING,
         allowNull: true,
-        validate: {
-            min: 0
-        }
+        defaultValue: null
     })
-    public radioFrequency: number | null;
+    public radioFrequency: string | null;
 
     /**
      * Tactical symbol
@@ -127,8 +128,9 @@ export class MissionSlotGroup extends Model {
      */
     @Attribute({
         type: DataTypes.ENUM,
-        values: ['inf'],
-        allowNull: true
+        values: tacticalSymbols,
+        allowNull: true,
+        defaultValue: null
     })
     public tacticalSymbol: string | null;
 
@@ -139,7 +141,8 @@ export class MissionSlotGroup extends Model {
      */
     @Attribute({
         type: DataTypes.STRING,
-        allowNull: true
+        allowNull: true,
+        defaultValue: null
     })
     public vehicle: string | null;
 
@@ -345,7 +348,7 @@ export interface IPublicMissionSlotGroup {
     parentGroupUid: string | null;
     missionUid: string;
     title: string;
-    radioFrequency: number | null;
+    radioFrequency: string | null;
     tacticalSymbol: string | null;
     vehicle: string | null;
     minSlottedPlayerCount: number;

--- a/src/shared/schemas/missionSlot.ts
+++ b/src/shared/schemas/missionSlot.ts
@@ -12,6 +12,9 @@ export const missionSlotSchema = Joi.object().keys({
     uid: Joi.string().guid().length(36).required().description('UID of the slot').example('e3af45b2-2ef8-4ece-bbcc-13e70f2b68a8'),
     slotGroupUid: Joi.string().guid().length(36).required().description('UID of the slot\'s slot group').example('e3af45b2-2ef8-4ece-bbcc-13e70f2b68a8'),
     title: Joi.string().min(1).max(255).required().description('Title of the slot').example('Platoon Lead'),
+    minSlottedPlayerCount: Joi.number()
+        .positive().allow(0).integer().optional().default(0)
+        .description('Lock slot until at least N players have slotted into the mission').example(12),
     orderNumber: Joi.number().integer().positive().allow(0).min(0).required().description('Order number for sorting slotlist').example(0),
     difficulty: Joi.number().integer().positive().allow(0).min(0).max(4).required().description('Difficulity of the slot, ranging from 0 (easiest) to 4 (hardest)').example(4),
     detailedDescription: Joi.string().allow(null).min(1).default(null).optional().description('Detailed, optional description of the mission slot, further explaining ' +

--- a/src/shared/schemas/missionSlotGroup.ts
+++ b/src/shared/schemas/missionSlotGroup.ts
@@ -1,5 +1,6 @@
 import * as Joi from 'joi';
 
+import {TacticalSymbol, tacticalSymbols} from '../types/tacticalSymbol';
 import { missionSlotSchema } from './missionSlot';
 
 /**
@@ -12,5 +13,11 @@ export const missionSlotGroupSchema = Joi.object().keys({
     orderNumber: Joi.number().integer().positive().allow(0).min(0).required().description('Order number for sorting slotlist').example(0),
     description: Joi.string().allow(null).min(1).default(null).optional().description('Optional description of the mission slot group, providing details about the group')
         .example('Spearhead of the operation, contains the most awesome people'),
+    radioFrequency: Joi.string().optional().max(255).default(null).description('Radio frequency or channel the group uses').example('52.3 MHz'),
+    tacticalSymbol: Joi.string().allow(tacticalSymbols).optional().default(null).description('tactical symbol').example(TacticalSymbol.mech_inf),
+    vehicle: Joi.string().max(64).optional().default(null).description('Vehicle the group uses').example('BTR-70'),
+    minSlottedPlayerCount: Joi.number()
+        .positive().allow(0).integer().optional().default(0)
+        .description('Lock slots of this group until at least N players have slotted into the mission').example(12),
     slots: Joi.array().items(missionSlotSchema.optional()).required().description('List of mission slots assigned to this slot group')
 }).required().label('MissionSlotGroup').description('Public mission slot group information, as displayed in slotlists');

--- a/src/shared/schemas/missionSlotGroup.ts
+++ b/src/shared/schemas/missionSlotGroup.ts
@@ -1,6 +1,6 @@
 import * as Joi from 'joi';
 
-import {TacticalSymbol, tacticalSymbols} from '../types/tacticalSymbol';
+import {TACTICAL_SYMBOL, tacticalSymbols} from '../types/tacticalSymbol';
 import { missionSlotSchema } from './missionSlot';
 
 /**
@@ -14,7 +14,7 @@ export const missionSlotGroupSchema = Joi.object().keys({
     description: Joi.string().allow(null).min(1).default(null).optional().description('Optional description of the mission slot group, providing details about the group')
         .example('Spearhead of the operation, contains the most awesome people'),
     radioFrequency: Joi.string().optional().max(255).default(null).description('Radio frequency or channel the group uses').example('52.3 MHz'),
-    tacticalSymbol: Joi.string().allow(tacticalSymbols).optional().default(null).description('tactical symbol').example(TacticalSymbol.mech_inf),
+    tacticalSymbol: Joi.string().allow(tacticalSymbols).optional().default(null).description('tactical symbol').example(TACTICAL_SYMBOL.mech_inf),
     vehicle: Joi.string().max(64).optional().default(null).description('Vehicle the group uses').example('BTR-70'),
     minSlottedPlayerCount: Joi.number()
         .positive().allow(0).integer().optional().default(0)

--- a/src/shared/types/tacticalSymbol.ts
+++ b/src/shared/types/tacticalSymbol.ts
@@ -1,22 +1,22 @@
 /**
  * represents allowed NATO tactical symbols. see https://community.bistudio.com/wiki/Military_Symbols
  */
-export enum TacticalSymbol {
-    inf = 'inf',
-    motor_inf = 'motor_inf',
-    mech_inf = 'mech_inf',
-    armor = 'armor',
-    recon = 'recon',
-    air = 'air',
-    plane = 'plane',
-    uav = 'uav',
-    med = 'med',
-    art = 'art',
-    mortar = 'mortar',
-    hq = 'hq',
-    service = 'service',
-    support = 'support',
-    maint = 'maint'
-}
+export const TACTICAL_SYMBOL = {
+    inf: 'inf',
+    motor_inf: 'motor_inf',
+    mech_inf : 'mech_inf',
+    armor : 'armor',
+    recon : 'recon',
+    air : 'air',
+    plane : 'plane',
+    uav : 'uav',
+    med : 'med',
+    art : 'art',
+    mortar : 'mortar',
+    hq : 'hq',
+    service : 'service',
+    support : 'support',
+    maint : 'maint'
+};
 
-export const tacticalSymbols = Object.keys(TacticalSymbol);
+export const tacticalSymbols = Object.keys(TACTICAL_SYMBOL);

--- a/src/shared/types/tacticalSymbol.ts
+++ b/src/shared/types/tacticalSymbol.ts
@@ -1,0 +1,22 @@
+/**
+ * represents allowed NATO tactical symbols
+ */
+export enum TacticalSymbol {
+    inf = 'inf',
+    motor_inf = 'motor_inf',
+    mech_inf = 'mech_inf',
+    armor = 'armor',
+    recon = 'recon',
+    air = 'air',
+    plane = 'plane',
+    uav = 'uav',
+    med = 'med',
+    art = 'art',
+    mortar = 'mortar',
+    hq = 'hq',
+    service = 'service',
+    support = 'support',
+    maint = 'maint'
+}
+
+export const tacticalSymbols = Object.keys(TacticalSymbol);

--- a/src/shared/types/tacticalSymbol.ts
+++ b/src/shared/types/tacticalSymbol.ts
@@ -1,5 +1,5 @@
 /**
- * represents allowed NATO tactical symbols
+ * represents allowed NATO tactical symbols. see https://community.bistudio.com/wiki/Military_Symbols
  */
 export enum TacticalSymbol {
     inf = 'inf',

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,9 +108,13 @@
   dependencies:
     "@types/bluebird" "*"
 
-"@types/bluebird@*", "@types/bluebird@^3.5.8":
+"@types/bluebird@*":
   version "3.5.20"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.20.tgz#f6363172add6f4eabb8cada53ca9af2781e8d6a1"
+
+"@types/bluebird@3.5.21":
+  version "3.5.21"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.21.tgz#567615589cc913e84a28ecf9edb031732bdf2634"
 
 "@types/bluebird@^3.5.5":
   version "3.5.8"


### PR DESCRIPTION
Add some fields to MissionSlotGroup:
* parentGroup - uid of a parent MissionSlotGroup
  Example: a squad belonging to a platoon
* radioFrequency - optional numeric radio frequency or channel
  Example: 50.1 for TFAR MHz, or 8 for a radio channel
* vehicle - optional string describing the vehicle a unit uses
  Example: "BTR-70"
* minSlottedPlayerCount: minimal number of *already* slotted
  players for this group to be slottable.
  Example: you want to have a full squad of 10 ppl rather than two
  half-strength squads of 5 ppl each. - So put minSlottedPlayerCount:=10 into the second squad

And added the minSlottedPlayerCount (see above) to MissionSlot.
  Example: non-essential slots like co-pilots you want to have
  slotted only after everything else


**TODO**

- [x] [joi](https://github.com/hapijs/joi) schemas, [see existing](https://github.com/MorpheusXAUT/slotlist-backend/blob/master/src/shared/schemas/missionSlotGroup.ts) 